### PR TITLE
docs: updated README and added changelog lint and CONTRIBUTING

### DIFF
--- a/.conventional-changelog-lintrc
+++ b/.conventional-changelog-lintrc
@@ -1,0 +1,11 @@
+{
+  "extends": ["angular"],
+  "rules": {
+    "body-tense": [0, "never"],
+    "header-max-length": [1, "always", 72],
+    "subject-tense": [0, "never"],
+    "footer-tense": [0, "never"],
+    "subject-case": [0, "never"],
+    "subject-full-stop": [0, "never"]
+  }
+}

--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,10 @@
 .*/node_modules/atom-linter
 .*/spec/fixtures
 
+# This ignores .json files in a bunch of places. It can go away when the
+# bug is fixed: https://github.com/facebook/flow/issues/1420
+.*/node_modules.*/\(binary\-extensions\|builtin\-modules\|iconv\-lite\|lib\|test\|url\-regex\|spdx\-exceptions\|spdx\-license\-ids\)/.*\.json$
+
 [include]
 lib
 spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,15 @@ notifications:
     on_success: never
     on_failure: change
 
+### workaround needed to be able to run conventional-changelog-lint on travis
+before_install:
+# Create a master branch for conventional-changelog-lint
+- git remote set-branches origin master
+- git fetch
+- git checkout master
+# Check out the commit that TravisCI started on:
+- git checkout -
+
 install:
 - npm install -g addons-linter
 - npm install -g flow-bin
@@ -10,6 +19,7 @@ install:
 script:
 - 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
 - flow check
+- npm run changelog-lint
 
 git:
   depth: 10
@@ -43,3 +53,8 @@ addons:
 branches:
   only:
   - master
+
+### cache node_modules/ dir between builds on travis
+cache:
+  directories:
+    - node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Development of atom-webextensions
+
+To get started, first install it from [source](README.md#installation-from-source).
+
+## Atom Development Mode
+
+Once you have linked the plugin repo to your Atom dev packages dir, as
+described in the above link, you can start an Atom instance in
+Development Mode at any yime by running it as `atom -d`.
+
+## Run all the plugin specs
+
+To run the entire suite of tests once and exit, type:
+
+    apm test
+
+If you want to run all the tests and checks that are running on travis
+(eslint and flow), type:
+
+    npm test
+
+### Check for lint
+
+Type `npm run lint` if you want to run only the eslint checks to make sure
+there are no syntax errors or other house keeping problems in the source code.
+
+### Check for Flow errors
+
+This project relies on [flow](http://flowtype.org/) to ensure functions and
+classes are used correctly. Run all flow checks with `npm run flow-check`.
+
+### Code Coverage
+
+TODO: not yet integrated
+
+## Writing commit messages
+
+This repo uses the same changelog generation strategy that we are using in [web-ext](https://github.com/mozilla/web-ext/blob/master/CONTRIBUTING.md#writing-commit-messages)
+
+First, try to follow the
+[standard git commit message style](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+This includes limiting the summary to 50 chars (which integrates well with git
+tools) but favor readability over conciseness if you need to go over that limit.
+
+Next, try adhering to the Angular style of
+[semantic messages](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit)
+when writing a commit message.
+This should allow us to auto-generate a changelog without too much noise in it.
+Additionally, write the commit message in past tense so it will read
+naturally as a historic changelog.
+
+Examples:
+* `feat: Added a systematic dysfunctioner`
+* `fix: Fixed hang in systematic dysfunctioner`
+* `docs: Improved contributor docs`
+* `style: Added no-console linting, cleaned up code`
+* `refactor: Split out dysfunctioner for testability`
+* `perf: Systematic dysfunctioner is now 2x faster`
+* `test: Added more tests for systematic dysfunctioner`
+* `chore: Upgraded yargs to 3.x.x`
+
+If you want to use scopes then it would look more like:
+`feat(dysfunctioner): Added --quiet option`.
+
+### Check for commit message lint
+
+You can test that your commit message is formatted in a way that will support
+our changelog generator like this:
+
+    npm run changelog-lint
+
+## Squashing commits
+
+When fixing up a pull request based on code review comments,
+[squash all commits together](https://github.com/ginatrapani/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit)
+before merging. This will allow us to auto-generate a more concise
+changelog. If a pull request contains more than one feature or fix then
+it is okay to include each as a separate commit.
+
+## Creating a release
+
+TODO: to be documented

--- a/README.md
+++ b/README.md
@@ -7,21 +7,29 @@ It currently provides the following features:
 - linting an addon project using the [addons-linter](https://github.com/mozilla/addons-linter)
 - open the WebExtensions MDN landing page
 
-## Documentation
-
-TBD
-
-## Installation from source
-
-Currently you need to install it from sources.
+## Installation from apm
 
 You'll need:
 * [Atom](https://atom.io/), 1.0 or higher
 
-Change into the source and install all dependencies:
+As an highly experimental Atom plugin, this is not yet installable directly from the
+Atom editor, but you can easily install it from the command line:
+
+    apm install rpl/atom-webextensions
+
+This command will clone the repo for you, installs any needed dependency module and
+finally install it into your Atom packages dir.
+
+## Installation from source
+
+If you want to hack on the plugin sources, you can easily clone this repo and link
+the plugin to Atom Development Mode:
 
     git clone https://github.com/rpl/atom-webextensions.git
     cd atom-webextensions
     apm install
     apm link --dev
     atom -d
+
+Take a look a [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to
+properly hack on the plugin sources (e.g. how to run tests, writing commit messages etc.)

--- a/package.json
+++ b/package.json
@@ -37,11 +37,15 @@
     "babel-eslint": "6.1.2",
     "eslint-config-airbnb-base": "5.0.0",
     "eslint-plugin-import": "1.12.0",
-    "eslint-plugin-babel": "3.3.0"
+    "eslint-plugin-babel": "3.3.0",
+    "conventional-changelog-cli": "1.2.0",
+    "conventional-changelog-lint": "1.0.0"
   },
   "scripts": {
     "flow-check": "flow check",
     "lint": "eslint .",
-    "test": "eslint . && flow check && apm test"
+    "test": "eslint . && flow check && apm test",
+    "changelog": "conventional-changelog -p angular -u",
+    "changelog-lint": "conventional-changelog-lint --from master"
   }
 }


### PR DESCRIPTION
This PR adds conventional-changelog (and conventional-changelog-lint step on travis) as described in the following Kumar's blogpost: https://blog.mozilla.org/webdev/2016/07/15/auto-generating-a-changelog-from-git-history/

Additionally, the README has been updated with instructions related to installation of the plugin from the command line, and a CONTRIBUTING file has been added (with information about how to properly hack on the plugin sources)
