### PR TITLE
test: help flow to check addons-linter message conversion helpers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@ extends: airbnb-base
 plugins:
 - babel
 - import
+- flow-vars
 
 globals:
   atom: true
@@ -20,3 +21,8 @@ rules:
 
   generator-star-spacing: 0
   babel/generator-star-spacing: 1
+
+  ### Fix issue with babel-eslint and flow type declarations
+
+  flow-vars/define-flow-type: 1
+  flow-vars/use-flow-type: 1

--- a/flow-typed/atom.js
+++ b/flow-typed/atom.js
@@ -18,8 +18,10 @@ declare class CompositeDisposableClass {
   dispose(): void;
 }
 
+export type Point = [number, number]
+export type Range = [Point, Point]
+
 declare module 'atom' {
-  declare var Range: any;
   declare var CompositeDisposable: any;
   declare var config: Config;
 }
@@ -37,7 +39,11 @@ declare class TextEditor {
   getLineCount(): number;
 }
 
+declare class LinterHelpers {
+  exec(exec: string, args: Array<string>, opts: any): Promise<string>;
+  rangeFromLineNumber(textEditor: TextEditor, line: number, col: number): Range;
+}
+
 declare module 'atom-linter' {
-  declare function exec(exec: string, args: Array<string>, opts: any): Promise<string>;
-  declare function rangeFromLineNumber(textEditor: TextEditor, line: number, col: number): Range;
+  declare var exports: LinterHelpers;
 }

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -7,6 +7,19 @@ import path from 'path';
 
 import * as messages from './messages';
 
+// Flow types
+
+type LinterMessageType = "Warning" | "Error";
+
+type AddonsLinterMessageConversionParams = {
+  helpers: LinterHelpers,
+  textEditor: TextEditor,
+  defaultRange: Range,
+  filePath: string
+}
+
+// Private internals
+
 const notifiedDisabledLintingOnProject = new Map();
 
 function isAddonProject(projectDirPath) {
@@ -32,7 +45,11 @@ function filterAddonLinterMessageByFile(isProject, fileRelPath) {
   return details => (isProject ? true : details.file === fileRelPath);
 }
 
-function convertAddonLinterMessage(helpers, textEditor, type, defaultRange, filePath) {
+function convertAddonLinterMessage(
+  type: LinterMessageType, conversionParams: AddonsLinterMessageConversionParams
+) {
+  const { helpers, textEditor, defaultRange, filePath } = conversionParams;
+
   return details => {
     let html;
     let range;
@@ -59,6 +76,8 @@ function convertAddonLinterMessage(helpers, textEditor, type, defaultRange, file
     };
   };
 }
+
+// Exported helpers
 
 export function addonsLinterForceOnProject() {
   const textEditor = atom.workspace.getActiveTextEditor();
@@ -202,13 +221,17 @@ export async function lint(textEditor: TextEditor, isProject: bool = false) {
 
   const fileRelPath = path.relative(projectDirPath, filePath);
 
+  const convertParams = {
+    helpers, textEditor, defaultRange, filePath,
+  };
+
   const warnings = results.warnings
         .filter(filterAddonLinterMessageByFile(isProject, fileRelPath))
-        .map(convertAddonLinterMessage(helpers, textEditor, 'Warning', defaultRange, filePath));
+          .map(convertAddonLinterMessage('Warning', convertParams));
 
   const errors = results.errors
         .filter(filterAddonLinterMessageByFile(isProject, fileRelPath))
-        .map(convertAddonLinterMessage(helpers, textEditor, 'Error', defaultRange, filePath));
+          .map(convertAddonLinterMessage('Error', convertParams));
 
   return []
     .concat(warnings)

--- a/package.json
+++ b/package.json
@@ -40,14 +40,15 @@
     }
   },
   "devDependencies": {
-    "flow-bin": "0.29.0",
-    "eslint": "3.1.1",
     "babel-eslint": "6.1.2",
-    "eslint-config-airbnb-base": "5.0.0",
-    "eslint-plugin-import": "1.12.0",
-    "eslint-plugin-babel": "3.3.0",
     "conventional-changelog-cli": "1.2.0",
-    "conventional-changelog-lint": "1.0.0"
+    "conventional-changelog-lint": "1.0.0",
+    "eslint": "3.1.1",
+    "eslint-config-airbnb-base": "5.0.0",
+    "eslint-plugin-babel": "3.3.0",
+    "eslint-plugin-flow-vars": "0.5.0",
+    "eslint-plugin-import": "1.12.0",
+    "flow-bin": "0.29.0"
   },
   "scripts": {
     "flow-check": "flow check",


### PR DESCRIPTION
This pull request introduces explicit flow type declarations of atom's `Point` and `Range` classes and an explicit flow type declarations for the params of the `convertAddonsLinterMessage` helper, to help flow to properly check that this private helper is used properly.
