### PR TITLE
fix: workarounded addons-linter issues in presence of a node_modules/ dir

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -208,9 +208,23 @@ export async function lint(
   const addonsLinterExecutable = atom.config
         .get('atom-webextensions.addonsLinterExecutablePath');
 
+  const addonsLinterTimeout = atom.config
+        .get('atom-webextensions.addonsLinterTimeout');
+
   const out = await helpers.exec(addonsLinterExecutable, [projectDirPath], {
     cwd: projectDir,
     ignoreExitCode: true,
+    timeout: addonsLinterTimeout || Infinity,
+  }).catch(e => {
+    if (e.message === 'Process execution timed out') {
+      atom.notifications.addError(messages.HOW_TO_FIX_LINTER_TIMEOUT, {
+        dismissable: true,
+      });
+    } else {
+      throw e;
+    }
+
+    return JSON.stringify({ errors: [], warnings: [] });
   });
 
   const results = JSON.parse(out);

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -5,3 +5,18 @@
 export const HOW_TO_FORCE_LINTING = 'You can force the WebExtensions linting on a project using the **addons-linter:force-on-this-project** command.';
 
 export const HOW_TO_CUSTOMIZE_TOOL_PATH = 'You can customize the path to the executable in the **WebExtensions Plugin Settings**';
+
+export const HOW_TO_FIX_LINTER_TIMEOUT = `
+  WebExtensions Plugin timed out running **addons-linter**:
+
+  <small>
+  This is probably due to a known **addons-linter** issue ([#3][issue-3],
+  and it is usually related to the presence of a \`node_modules/\` dir in the project.
+
+  As a workaround (at least until the issue is fixed on the **addons-linter** itself),
+  you can remove the content of the \`node_modules/\` dir or customize the timeout
+  in the Package Settings.
+  </small>
+
+  [issue-3]: https://github.com/rpl/atom-webextensions/issues/3
+`;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -18,6 +18,11 @@ export default {
       default: 'addons-linter',
       description: 'Absolute path to the **addons-linter** executable on your system.',
     },
+    addonsLinterTimeout: {
+      type: 'number',
+      default: '5000',
+      description: 'Maximum time to wait for **addons-linter** results (defaults to 5000 ms)',
+    },
     webextExecutablePath: {
       type: 'string',
       default: 'web-ext',


### PR DESCRIPTION
This PR introduces a new `addonsLinterTimeout` in the available package settings, and the plugin now runs the `addons-linter` executable using that value as the number of milliseconds to wait for linting results,
then it fails by alerting the user of the known #3 issue and explain how it is usually possible to workaround it.

This doesn't fully fix #3 but it should be enough to prevent this plugin to make this issue worst by spawning an "invisible huge number of node processes" due to the "linting on the fly" behavior of this plugin (at least until we have a better option to solve it, mozilla/addons-linter#849).  
